### PR TITLE
bigdecimal is standard library

### DIFF
--- a/round_50sen.gemspec
+++ b/round_50sen.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'bigdecimal'
-
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
`add_dependency` is not needed because of Ruby provides built-in support for BigDecimal.